### PR TITLE
Make $ optional

### DIFF
--- a/src/jsonpath_parser.yrl
+++ b/src/jsonpath_parser.yrl
@@ -21,6 +21,7 @@ Terminals '.' '$' '[' ']' '@' '?' '(' ')' '==' '!=' identifier integer string.
 Rootsymbol jsonpath.
 
 jsonpath -> identifier : [{access, extract_token('$1')}].
+jsonpath -> identifier path : [{access, extract_token('$1')} | '$2'].
 jsonpath -> '$' path : '$2'.
 
 path -> child : '$1'.

--- a/test/ex_json_path_test.exs
+++ b/test/ex_json_path_test.exs
@@ -94,4 +94,22 @@ defmodule ExJsonPathTest do
 
     assert ExJsonPath.eval(map, path) == [0.1, 0.3]
   end
+
+  # This is not described [here](https://goessner.net/articles/JsonPath/)
+  # but his implementation supports it, and nearly every other implementation.
+  test "hello" do
+    map = %{"hello" => %{"world" => "test"}}
+    path = "hello"
+
+    assert ExJsonPath.eval(map, path) == %{"world" => "test"}
+  end
+
+  # This is not described [here](https://goessner.net/articles/JsonPath/)
+  # but his implementation supports it, and nearly every other implementation.
+  test "hello.world" do
+    map = %{"hello" => %{"world" => "test"}}
+    path = "hello.world"
+
+    assert ExJsonPath.eval(map, path) == "test"
+  end
 end


### PR DESCRIPTION
Make it easier to write JSONPaths allowing foo.bar instead of $.foo.bar.