### PR TITLE
Add union operator

### DIFF
--- a/lib/ex_json_path.ex
+++ b/lib/ex_json_path.ex
@@ -157,6 +157,12 @@ defmodule ExJsonPath do
   defp recurse(_any, [{:recurse, _a} | _t]),
     do: []
 
+  defp recurse(enumerable, [{:union, union_list} | t]) do
+    Enum.reduce(union_list, [], fn union_item, acc ->
+      acc ++ recurse(enumerable, [union_item | t])
+    end)
+  end
+
   defp recurse(%{} = map, [:wildcard | t]) do
     Map.values(map)
     |> Enum.reduce([], fn item, acc -> acc ++ recurse(item, t) end)

--- a/src/jsonpath_parser.yrl
+++ b/src/jsonpath_parser.yrl
@@ -16,7 +16,7 @@
 % limitations under the License.
 %
 
-Nonterminals jsonpath path child filter_expression expression value comparison_operator.
+Nonterminals jsonpath path child index filter_expression expression value comparison_operator.
 Terminals '.' '..' '*' '$' '[' ']' '@' '?' '(' ')' '>' '>=' '<' '<=' '==' '!=' identifier integer string.
 Rootsymbol jsonpath.
 
@@ -35,9 +35,11 @@ child -> '..' integer : [{recurse, extract_token('$2')}].
 child -> '.' '*' : [wildcard].
 child -> '.' identifier : [{access, extract_token('$2')}].
 child -> '.' integer : [{access, extract_token('$2')}].
-child -> '[' integer ']' : [{access, extract_token('$2')}].
-child -> '[' string ']' : [{access, extract_token('$2')}].
-child -> '[' filter_expression ']' : [{access, '$2'}].
+child -> '[' index ']' : '$2'.
+
+index -> integer : [{access, extract_token('$1')}].
+index -> string : [{access, extract_token('$1')}].
+index -> filter_expression : [{access, '$1'}].
 
 filter_expression -> '?' '(' expression ')' : '$3'.
 

--- a/src/jsonpath_parser.yrl
+++ b/src/jsonpath_parser.yrl
@@ -16,8 +16,8 @@
 % limitations under the License.
 %
 
-Nonterminals jsonpath path child index filter_expression expression value comparison_operator.
-Terminals '.' '..' '*' '$' '[' ']' '@' '?' '(' ')' '>' '>=' '<' '<=' '==' '!=' identifier integer string.
+Nonterminals jsonpath path child index union indexes filter_expression expression value comparison_operator.
+Terminals '.' '..' '*' '$' '[' ']' ',' '@' '?' '(' ')' '>' '>=' '<' '<=' '==' '!=' identifier integer string.
 Rootsymbol jsonpath.
 
 jsonpath -> integer : [{access, extract_token('$1')}].
@@ -35,11 +35,16 @@ child -> '..' integer : [{recurse, extract_token('$2')}].
 child -> '.' '*' : [wildcard].
 child -> '.' identifier : [{access, extract_token('$2')}].
 child -> '.' integer : [{access, extract_token('$2')}].
-child -> '[' index ']' : '$2'.
+child -> '[' index ']' : ['$2'].
+child -> '[' union ']' : ['$2'].
 
-index -> integer : [{access, extract_token('$1')}].
-index -> string : [{access, extract_token('$1')}].
-index -> filter_expression : [{access, '$1'}].
+union -> indexes: {union,  '$1'}.
+indexes -> index ',' index : ['$1', '$3'].
+indexes -> index ',' indexes : ['$1' | '$3'].
+
+index -> integer : {access, extract_token('$1')}.
+index -> string : {access, extract_token('$1')}.
+index -> filter_expression : {access, '$1'}.
 
 filter_expression -> '?' '(' expression ')' : '$3'.
 

--- a/test/ex_json_path_test.exs
+++ b/test/ex_json_path_test.exs
@@ -445,6 +445,73 @@ defmodule ExJsonPathTest do
     end
   end
 
+  describe "union operator" do
+    test ~s{eval $.test["a","b","c"]} do
+      map = %{"test" => %{"a" => 4, "b" => "hello", "c" => 2}}
+
+      path = ~s{$.test["a","b","c"]}
+
+      assert ExJsonPath.eval(map, path) == {:ok, [4, "hello", 2]}
+    end
+
+    test ~s{eval $.test["c","b","a"]} do
+      map = %{"test" => %{"a" => 4, "b" => "hello", "c" => 2}}
+
+      path = ~s{$.test["c","b","a"]}
+
+      assert ExJsonPath.eval(map, path) == {:ok, [2, "hello", 4]}
+    end
+
+    test ~s{eval $.test["c","c","a"]} do
+      map = %{"test" => %{"a" => 4, "b" => "hello", "c" => 2}}
+
+      path = ~s{$.test["c","c","a"]}
+
+      assert ExJsonPath.eval(map, path) == {:ok, [2, 2, 4]}
+    end
+
+    test ~s{eval $.test[4,2,0]} do
+      map = %{"test" => ["0", "1", "2", "3", "4", "5"]}
+
+      path = ~s{$.test[4,2,0]}
+
+      assert ExJsonPath.eval(map, path) == {:ok, ["4", "2", "0"]}
+    end
+
+    test ~s{eval $.test[0,0,?(@.a == "ok")]} do
+      map = %{"test" => [%{"b" => "test"}, %{"a" => "foo"}, %{"a" => "ok"}]}
+
+      path = ~s{$.test[0,0,?(@.a == "ok")]}
+
+      assert ExJsonPath.eval(map, path) ==
+               {:ok, [%{"b" => "test"}, %{"b" => "test"}, %{"a" => "ok"}]}
+    end
+
+    test ~s{eval $.test[0,100,?(@.a == "ok")]} do
+      map = %{"test" => [%{"b" => "test"}, %{"a" => "foo"}, %{"a" => "ok"}]}
+
+      path = ~s{$.test[0,100,?(@.a == "ok")]}
+
+      assert ExJsonPath.eval(map, path) == {:ok, [%{"b" => "test"}, %{"a" => "ok"}]}
+    end
+
+    test ~s{eval $.test[0,0,?(@.a == "ok")].a} do
+      map = %{"test" => [%{"b" => "test"}, %{"a" => "foo"}, %{"a" => "ok"}]}
+
+      path = ~s{$.test[0,0,?(@.a == "ok")].a}
+
+      assert ExJsonPath.eval(map, path) == {:ok, ["ok"]}
+    end
+
+    test ~s{eval $.test[0,0,?(@.a == "ok")].z} do
+      map = %{"test" => [%{"b" => "test"}, %{"a" => "foo"}, %{"a" => "ok"}]}
+
+      path = ~s{$.test[0,0,?(@.a == "ok")].z}
+
+      assert ExJsonPath.eval(map, path) == {:ok, []}
+    end
+  end
+
   describe "eval $[?(@.v OPERATOR 1)] expressions" do
     test ~s{with == operator} do
       array = [

--- a/test/jsonpath_parser_test.exs
+++ b/test/jsonpath_parser_test.exs
@@ -55,4 +55,40 @@ defmodule ExJsonPath.Parser do
                 access: "value"
               ]}
   end
+
+  test "tokenize and parse union with 2 indexes" do
+    {:ok, tokens, _} = :jsonpath_lexer.string('$.values[1,"a"].value')
+
+    assert :jsonpath_parser.parse(tokens) ==
+             {:ok,
+              [
+                access: "values",
+                union: [access: 1, access: "a"],
+                access: "value"
+              ]}
+  end
+
+  test "tokenize and parse union with 3 indexes" do
+    {:ok, tokens, _} = :jsonpath_lexer.string('$.values[1,"a",2].value')
+
+    assert :jsonpath_parser.parse(tokens) ==
+             {:ok,
+              [
+                access: "values",
+                union: [access: 1, access: "a", access: 2],
+                access: "value"
+              ]}
+  end
+
+  test "tokenize and parse union with filter" do
+    {:ok, tokens, _} = :jsonpath_lexer.string('$.values[1,?(@.a > 1)].value')
+
+    assert :jsonpath_parser.parse(tokens) ==
+             {:ok,
+              [
+                access: "values",
+                union: [access: 1, access: {:>, [access: "a"], 1}],
+                access: "value"
+              ]}
+  end
 end


### PR DESCRIPTION
Implement union operator, that is used for expressions such as `$.test[4,2,0]`.

When used with `%{"test" => ["0", "1", "2", "3", "4", "5"]}` the expresion return value is `{:ok, ["4", "2", "0"]}`.