### PR TITLE
Add slice operator

### DIFF
--- a/src/jsonpath_parser.yrl
+++ b/src/jsonpath_parser.yrl
@@ -16,8 +16,8 @@
 % limitations under the License.
 %
 
-Nonterminals jsonpath path child index union indexes filter_expression expression value comparison_operator.
-Terminals '.' '..' '*' '$' '[' ']' ',' '@' '?' '(' ')' '>' '>=' '<' '<=' '==' '!=' identifier integer string.
+Nonterminals jsonpath path child index union indexes slice filter_expression expression value comparison_operator.
+Terminals '.' '..' '*' '$' '[' ']' ',' ':' '@' '?' '(' ')' '>' '>=' '<' '<=' '==' '!=' identifier integer string.
 Rootsymbol jsonpath.
 
 jsonpath -> integer : [{access, extract_token('$1')}].
@@ -44,7 +44,22 @@ indexes -> index ',' indexes : ['$1' | '$3'].
 
 index -> integer : {access, extract_token('$1')}.
 index -> string : {access, extract_token('$1')}.
+index -> slice : '$1'.
 index -> filter_expression : {access, '$1'}.
+
+slice -> integer ':' integer ':' integer : {slice, extract_token('$1'), extract_token('$3'), extract_token('$5')}.
+slice -> ':' ':' : {slice, 0, last, 1}.
+slice -> ':' ':' integer : {slice, 0, last, extract_token('$3')}.
+slice -> ':' integer ':' : {slice, 0, extract_token('$2'), 1}.
+slice -> ':' integer ':' integer : {slice, 0, extract_token('$2'), extract_token('$4')}.
+slice -> integer ':' ':' : {slice, extract_token('$1'), last, 1}.
+slice -> integer ':' ':' integer : {slice, extract_token('$1'), last, extract_token('$4')}.
+slice -> integer ':' integer ':' : {slice, extract_token('$1'), extract_token('$3'), 1}.
+
+slice -> integer ':' integer : {slice, extract_token('$1'), extract_token('$3'), 1}.
+slice -> ':' : {slice, 0, last, 1}.
+slice -> ':' integer : {slice, 0, extract_token('$2'), 1}.
+slice -> integer ':' : {slice, extract_token('$1'), last, 1}.
 
 filter_expression -> '?' '(' expression ')' : '$3'.
 

--- a/test/ex_json_path_test.exs
+++ b/test/ex_json_path_test.exs
@@ -512,6 +512,56 @@ defmodule ExJsonPathTest do
     end
   end
 
+  describe "slice operator" do
+    test ~s{eval $.data[0:5]} do
+      map = %{"data" => [0, -1, 2, -3, 4, -5, 6, -7, 8]}
+
+      path = ~s{$.data[0:5]}
+
+      assert ExJsonPath.eval(map, path) == {:ok, [0, -1, 2, -3, 4]}
+    end
+
+    test ~s{eval $.data[:5]} do
+      map = %{"data" => [0, -1, 2, -3, 4, -5, 6, -7, 8]}
+
+      path = ~s{$.data[:5]}
+
+      assert ExJsonPath.eval(map, path) == {:ok, [0, -1, 2, -3, 4]}
+    end
+
+    test ~s{eval $.data[::2]} do
+      map = %{"data" => [0, -1, 2, -3, 4, -5, 6, -7, 8]}
+
+      path = ~s{$.data[::2]}
+
+      assert ExJsonPath.eval(map, path) == {:ok, [0, 2, 4, 6, 8]}
+    end
+
+    test ~s{eval $.data[1::2]} do
+      map = %{"data" => [0, -1, 2, -3, 4, -5, 6, -7, 8]}
+
+      path = ~s{$.data[1::2]}
+
+      assert ExJsonPath.eval(map, path) == {:ok, [-1, -3, -5, -7]}
+    end
+
+    test ~s{eval $.data[1:3]} do
+      map = %{"data" => [0, -1, 2, -3, 4, -5, 6, -7, 8]}
+
+      path = ~s{$.data[1:3]}
+
+      assert ExJsonPath.eval(map, path) == {:ok, [-1, 2]}
+    end
+
+    test ~s{eval $.data[0:2,7:9]} do
+      map = %{"data" => [0, -1, 2, -3, 4, -5, 6, -7, 8]}
+
+      path = ~s{$.data[0:2,7:9]}
+
+      assert ExJsonPath.eval(map, path) == {:ok, [0, -1, -7, 8]}
+    end
+  end
+
   describe "eval $[?(@.v OPERATOR 1)] expressions" do
     test ~s{with == operator} do
       array = [

--- a/test/jsonpath_parser_test.exs
+++ b/test/jsonpath_parser_test.exs
@@ -91,4 +91,78 @@ defmodule ExJsonPath.Parser do
                 access: "value"
               ]}
   end
+
+  describe "tokenize and parse slice operator" do
+    test "1:2" do
+      {:ok, tokens, _} = :jsonpath_lexer.string('$.values[1:2]')
+
+      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 1, 2, 1}]}
+    end
+
+    test "1:2:3" do
+      {:ok, tokens, _} = :jsonpath_lexer.string('$.values[1:2:3]')
+
+      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 1, 2, 3}]}
+    end
+
+    test ":" do
+      {:ok, tokens, _} = :jsonpath_lexer.string('$.values[:]')
+
+      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 0, :last, 1}]}
+    end
+
+    test ":1" do
+      {:ok, tokens, _} = :jsonpath_lexer.string('$.values[:1]')
+
+      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 0, 1, 1}]}
+    end
+
+    test "1:" do
+      {:ok, tokens, _} = :jsonpath_lexer.string('$.values[1:]')
+
+      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 1, :last, 1}]}
+    end
+
+    test "::" do
+      {:ok, tokens, _} = :jsonpath_lexer.string('$.values[::]')
+
+      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 0, :last, 1}]}
+    end
+
+    test "::2" do
+      {:ok, tokens, _} = :jsonpath_lexer.string('$.values[::2]')
+
+      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 0, :last, 2}]}
+    end
+
+    test ":2:" do
+      {:ok, tokens, _} = :jsonpath_lexer.string('$.values[:2:]')
+
+      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 0, 2, 1}]}
+    end
+
+    test ":2:3" do
+      {:ok, tokens, _} = :jsonpath_lexer.string('$.values[:2:3]')
+
+      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 0, 2, 3}]}
+    end
+
+    test "2::" do
+      {:ok, tokens, _} = :jsonpath_lexer.string('$.values[2::]')
+
+      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 2, :last, 1}]}
+    end
+
+    test "2::2" do
+      {:ok, tokens, _} = :jsonpath_lexer.string('$.values[2::2]')
+
+      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 2, :last, 2}]}
+    end
+
+    test "2:2:" do
+      {:ok, tokens, _} = :jsonpath_lexer.string('$.values[2:2:]')
+
+      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 2, 2, 1}]}
+    end
+  end
 end


### PR DESCRIPTION
Add support for expressions such as `$.values[1:10:2]`, which returns `[1, 3, 5, 7, 9]`
when  input is `{"values": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}`.