### PR TITLE
Just $ can be used for the root

### DIFF
--- a/src/jsonpath_parser.yrl
+++ b/src/jsonpath_parser.yrl
@@ -25,6 +25,7 @@ jsonpath -> identifier : [{access, extract_token('$1')}].
 jsonpath -> child : '$1'.
 jsonpath -> integer path : [{access, extract_token('$1')} | '$2'].
 jsonpath -> identifier path : [{access, extract_token('$1')} | '$2'].
+jsonpath -> '$' : [].
 jsonpath -> '$' path : '$2'.
 
 path -> child : '$1'.

--- a/test/ex_json_path_test.exs
+++ b/test/ex_json_path_test.exs
@@ -296,6 +296,15 @@ defmodule ExJSONPathTest do
     assert ExJSONPath.eval(value, path) == {:ok, []}
   end
 
+  # Goessner was not supporting this, however this is handy and supported by most implementations
+  # https://cburgmer.github.io/json-path-comparison/results/root.html
+  test "eval $" do
+    map = %{"a" => %{"b" => 42}}
+    path = ~s{$}
+
+    assert ExJSONPath.eval(map, path) == {:ok, [map]}
+  end
+
   describe ".. operator" do
     test "eval $..a on a nested object" do
       map = %{
@@ -648,13 +657,6 @@ defmodule ExJSONPathTest do
   end
 
   describe "parsing error" do
-    test ~s{with eval $} do
-      map = %{"a" => %{"b" => 42}}
-      path = ~s{$}
-
-      assert {:error, %ParsingError{message: "" <> _msg}} = ExJSONPath.eval(map, path)
-    end
-
     test ~s{with eval @} do
       map = %{"a" => %{"b" => 42}}
       path = ~s{@}


### PR DESCRIPTION
Make it behave like most implementations:
https://cburgmer.github.io/json-path-comparison/results/root.html

Our initial implementation was explicitly not supporting $, however it
is handy and most implementations around are supporting this.