### PR TITLE
Slice operator on objects always eval to []

### DIFF
--- a/lib/ex_json_path.ex
+++ b/lib/ex_json_path.ex
@@ -158,6 +158,9 @@ defmodule ExJSONPath do
   defp recurse(_any, [{:recurse, _a} | _t]),
     do: []
 
+  defp recurse(map, [{:slice, _first, _last, _step} | _t]) when is_map(map),
+    do: []
+
   defp recurse(enumerable, [{:slice, first, :last, step} | t]),
     do: recurse(enumerable, [{:slice, first, Enum.count(enumerable), step} | t])
 

--- a/test/ex_json_path_test.exs
+++ b/test/ex_json_path_test.exs
@@ -603,6 +603,22 @@ defmodule ExJSONPathTest do
 
       assert ExJSONPath.eval(map, path) == {:ok, [0, -1, -7, 8]}
     end
+
+    test ~s{eval $.data[1:3] on object} do
+      map = %{"data" => %{"a" => 0, "b" => -1, "c" => 2, "d" => -3, "e" => 4}}
+
+      path = ~s{$.data[1:3]}
+
+      assert ExJSONPath.eval(map, path) == {:ok, []}
+    end
+
+    test ~s{eval $.data[1:3:2] on object} do
+      map = %{"data" => %{"a" => 0, "b" => -1, "c" => 2, "d" => -3, "e" => 4}}
+
+      path = ~s{$.data[1:3:2]}
+
+      assert ExJSONPath.eval(map, path) == {:ok, []}
+    end
   end
 
   describe "eval $[?(@.v OPERATOR 1)] expressions" do


### PR DESCRIPTION
`{":": 42, "more": "string", "a": 1, "b": 2, "c": 3}` on `$[1:3]` outputs `[]`.
See also https://cburgmer.github.io/json-path-comparison/results/array_slice_on_object.html