### PR TITLE
Support leading @

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ iex(3)> ExJSONPath.eval(store, "$.store.book[?(@.price > 20)].title")
 
 Full documentation can be found at [hexdocs.pm/exjsonpath](https://hexdocs.pm/exjsonpath).
 
+## Notes
+
+Expressions with no leading selector (`$` or `@`) default to current item, however they are a
+common extension to JSONPath that should be avoided for compatibility reasons.
+
 ## About This Project
 
 This project has been created in order to provide support to JSONPath to [Astarte Flow](https://github.com/astarte-platform/astarte_flow).

--- a/lib/ex_json_path.ex
+++ b/lib/ex_json_path.ex
@@ -98,6 +98,12 @@ defmodule ExJSONPath do
   defp recurse(item, []),
     do: [item]
 
+  defp recurse(item, [:root | t]),
+    do: recurse(item, t)
+
+  defp recurse(item, [:current_item | t]),
+    do: recurse(item, t)
+
   defp recurse(enumerable, [{:access, {op, path, value}} | t])
        when is_list(enumerable) or is_map(enumerable) do
     results =

--- a/src/jsonpath_parser.yrl
+++ b/src/jsonpath_parser.yrl
@@ -16,7 +16,7 @@
 % limitations under the License.
 %
 
-Nonterminals jsonpath path child index union indexes slice filter_expression expression value comparison_operator.
+Nonterminals jsonpath start_selector path child index union indexes slice filter_expression expression value comparison_operator.
 Terminals '.' '..' '*' '$' '[' ']' ',' ':' '@' '?' '(' ')' '>' '>=' '<' '<=' '==' '!=' identifier integer string.
 Rootsymbol jsonpath.
 
@@ -25,10 +25,11 @@ jsonpath -> identifier : [{access, extract_token('$1')}].
 jsonpath -> child : '$1'.
 jsonpath -> integer path : [{access, extract_token('$1')} | '$2'].
 jsonpath -> identifier path : [{access, extract_token('$1')} | '$2'].
-jsonpath -> '$' : [root].
-jsonpath -> '$' path : [root | '$2'].
-jsonpath -> '@' : [current_item].
-jsonpath -> '@' path : [current_item | '$2'].
+jsonpath -> start_selector : ['$1'].
+jsonpath -> start_selector path : ['$1' | '$2'].
+
+start_selector -> '$' : root.
+start_selector -> '@' : current_item.
 
 path -> child : '$1'.
 path -> path child : '$1' ++ '$2'.

--- a/src/jsonpath_parser.yrl
+++ b/src/jsonpath_parser.yrl
@@ -25,8 +25,10 @@ jsonpath -> identifier : [{access, extract_token('$1')}].
 jsonpath -> child : '$1'.
 jsonpath -> integer path : [{access, extract_token('$1')} | '$2'].
 jsonpath -> identifier path : [{access, extract_token('$1')} | '$2'].
-jsonpath -> '$' : [].
-jsonpath -> '$' path : '$2'.
+jsonpath -> '$' : [root].
+jsonpath -> '$' path : [root | '$2'].
+jsonpath -> '@' : [current_item].
+jsonpath -> '@' path : [current_item | '$2'].
 
 path -> child : '$1'.
 path -> path child : '$1' ++ '$2'.

--- a/test/ex_json_path_test.exs
+++ b/test/ex_json_path_test.exs
@@ -733,14 +733,17 @@ defmodule ExJSONPathTest do
     end
   end
 
-  describe "parsing error" do
-    test ~s{with eval @} do
-      map = %{"a" => %{"b" => 42}}
-      path = ~s{@}
+  describe "relative paths" do
+    test "simple relative path with leading @" do
+      map = %{"a" => "test"}
 
-      assert {:error, %ParsingError{message: "" <> _msg}} = ExJSONPath.eval(map, path)
+      path = "@.a"
+
+      assert ExJSONPath.eval(map, path) == {:ok, ["test"]}
     end
+  end
 
+  describe "parsing error" do
     test "with invalid expression" do
       map = %{"a" => %{"b" => 42}}
       path = ~s{$[?()]}

--- a/test/jsonpath_parser_test.exs
+++ b/test/jsonpath_parser_test.exs
@@ -22,24 +22,25 @@ defmodule ExJSONPath.Parser do
   test "parse already tokenized simple json path" do
     tokens = [{:"$", 1}, {:., 1}, {:identifier, 1, "hello"}, {:., 1}, {:identifier, 1, "world"}]
 
-    assert :jsonpath_parser.parse(tokens) == {:ok, [access: "hello", access: "world"]}
+    assert :jsonpath_parser.parse(tokens) == {:ok, [:root, access: "hello", access: "world"]}
   end
 
   test "tokenize and parse simple json path" do
     {:ok, tokens, _} = :jsonpath_lexer.string('$.hello.world')
-    assert :jsonpath_parser.parse(tokens) == {:ok, [access: "hello", access: "world"]}
+    assert :jsonpath_parser.parse(tokens) == {:ok, [:root, access: "hello", access: "world"]}
   end
 
   test "tokenize and parse simple json with braket notation" do
     {:ok, tokens, _} = :jsonpath_lexer.string('$[\'hello\'][\'world\']')
-    assert :jsonpath_parser.parse(tokens) == {:ok, [access: "hello", access: "world"]}
+    assert :jsonpath_parser.parse(tokens) == {:ok, [:root, access: "hello", access: "world"]}
   end
 
   test "tokenize and parse path with arrays" do
     {:ok, tokens, _} = :jsonpath_lexer.string('$.data[0].values[-1].value')
 
     assert :jsonpath_parser.parse(tokens) ==
-             {:ok, [access: "data", access: 0, access: "values", access: -1, access: "value"]}
+             {:ok,
+              [:root, access: "data", access: 0, access: "values", access: -1, access: "value"]}
   end
 
   test "tokenize and parse complex path" do
@@ -48,6 +49,7 @@ defmodule ExJSONPath.Parser do
     assert :jsonpath_parser.parse(tokens) ==
              {:ok,
               [
+                :root,
                 access: "data",
                 access: 0,
                 access: "values",
@@ -62,6 +64,7 @@ defmodule ExJSONPath.Parser do
     assert :jsonpath_parser.parse(tokens) ==
              {:ok,
               [
+                :root,
                 access: "values",
                 union: [access: 1, access: "a"],
                 access: "value"
@@ -74,6 +77,7 @@ defmodule ExJSONPath.Parser do
     assert :jsonpath_parser.parse(tokens) ==
              {:ok,
               [
+                :root,
                 access: "values",
                 union: [access: 1, access: "a", access: 2],
                 access: "value"
@@ -86,6 +90,7 @@ defmodule ExJSONPath.Parser do
     assert :jsonpath_parser.parse(tokens) ==
              {:ok,
               [
+                :root,
                 access: "values",
                 union: [access: 1, access: {:>, [access: "a"], 1}],
                 access: "value"
@@ -96,73 +101,85 @@ defmodule ExJSONPath.Parser do
     test "1:2" do
       {:ok, tokens, _} = :jsonpath_lexer.string('$.values[1:2]')
 
-      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 1, 2, 1}]}
+      assert :jsonpath_parser.parse(tokens) ==
+               {:ok, [:root, {:access, "values"}, {:slice, 1, 2, 1}]}
     end
 
     test "1:2:3" do
       {:ok, tokens, _} = :jsonpath_lexer.string('$.values[1:2:3]')
 
-      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 1, 2, 3}]}
+      assert :jsonpath_parser.parse(tokens) ==
+               {:ok, [:root, {:access, "values"}, {:slice, 1, 2, 3}]}
     end
 
     test ":" do
       {:ok, tokens, _} = :jsonpath_lexer.string('$.values[:]')
 
-      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 0, :last, 1}]}
+      assert :jsonpath_parser.parse(tokens) ==
+               {:ok, [:root, {:access, "values"}, {:slice, 0, :last, 1}]}
     end
 
     test ":1" do
       {:ok, tokens, _} = :jsonpath_lexer.string('$.values[:1]')
 
-      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 0, 1, 1}]}
+      assert :jsonpath_parser.parse(tokens) ==
+               {:ok, [:root, {:access, "values"}, {:slice, 0, 1, 1}]}
     end
 
     test "1:" do
       {:ok, tokens, _} = :jsonpath_lexer.string('$.values[1:]')
 
-      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 1, :last, 1}]}
+      assert :jsonpath_parser.parse(tokens) ==
+               {:ok, [:root, {:access, "values"}, {:slice, 1, :last, 1}]}
     end
 
     test "::" do
       {:ok, tokens, _} = :jsonpath_lexer.string('$.values[::]')
 
-      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 0, :last, 1}]}
+      assert :jsonpath_parser.parse(tokens) ==
+               {:ok, [:root, {:access, "values"}, {:slice, 0, :last, 1}]}
     end
 
     test "::2" do
       {:ok, tokens, _} = :jsonpath_lexer.string('$.values[::2]')
 
-      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 0, :last, 2}]}
+      assert :jsonpath_parser.parse(tokens) ==
+               {:ok, [:root, {:access, "values"}, {:slice, 0, :last, 2}]}
     end
 
     test ":2:" do
       {:ok, tokens, _} = :jsonpath_lexer.string('$.values[:2:]')
 
-      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 0, 2, 1}]}
+      assert :jsonpath_parser.parse(tokens) ==
+               {:ok, [:root, {:access, "values"}, {:slice, 0, 2, 1}]}
     end
 
     test ":2:3" do
       {:ok, tokens, _} = :jsonpath_lexer.string('$.values[:2:3]')
 
-      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 0, 2, 3}]}
+      assert :jsonpath_parser.parse(tokens) ==
+               {:ok, [:root, {:access, "values"}, {:slice, 0, 2, 3}]}
     end
 
     test "2::" do
       {:ok, tokens, _} = :jsonpath_lexer.string('$.values[2::]')
 
-      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 2, :last, 1}]}
+      assert :jsonpath_parser.parse(tokens) ==
+               {:ok, [:root, {:access, "values"}, {:slice, 2, :last, 1}]}
     end
 
     test "2::2" do
       {:ok, tokens, _} = :jsonpath_lexer.string('$.values[2::2]')
 
-      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 2, :last, 2}]}
+      assert :jsonpath_parser.parse(tokens) ==
+               {:ok, [:root, {:access, "values"}, {:slice, 2, :last, 2}]}
     end
 
     test "2:2:" do
       {:ok, tokens, _} = :jsonpath_lexer.string('$.values[2:2:]')
 
-      assert :jsonpath_parser.parse(tokens) == {:ok, [{:access, "values"}, {:slice, 2, 2, 1}]}
+      assert :jsonpath_parser.parse(tokens) ==
+               {:ok, [:root, {:access, "values"}, {:slice, 2, 2, 1}]}
     end
   end
 end


### PR DESCRIPTION
Expressions with leading `@` are supported now (e.g. `@.b`).

eval/3 is available now, and it enables to set a JSON subdocument as current item, that can be selected using `@` (which is different than `$`).